### PR TITLE
Program changes: day 4, titles, no time stamp.

### DIFF
--- a/23m/schedule/assets/css/style.css
+++ b/23m/schedule/assets/css/style.css
@@ -3039,7 +3039,7 @@ a {
     padding: var(--space-xs);
     box-shadow: inset 0 -3px 0 rgba(0, 0, 0, 0.2);
     text-decoration: none; }
-  .cd-schedule__event a::before {
+  .cd-schedule__event a {
     content: attr(data-start) " - " attr(data-end); }
   @media (min-width: 48rem) {
     .js .cd-schedule__event {

--- a/23m/schedule/index.html
+++ b/23m/schedule/index.html
@@ -137,85 +137,85 @@ external_css: [assets/css/style.css]
 
             <li class="cd-schedule__event">
               <a data-day="0" data-start="08:00" data-end="10:00" data-content="ses_inclusive_science" data-event="event-1" href="#0">
-                <em class="cd-schedule__name">Globally Inclusive Science</em>
+                <em class="cd-schedule__name">Embracing diversity in MRI: A journey towards globally inclusive science</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="13:00" data-end="14:30" data-content="ses_hardware" data-event="event-2" href="#0">
-                <em class="cd-schedule__name">Open Hardware</em>
+                <em class="cd-schedule__name">Building tomorrow's MRI: A roadmap to open source hardware</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
-              <a data-start="14:30" data-end="15:00" data-content="networking_1" data-event="event-6" href="#0">
-                <em class="cd-schedule__name">Networking Session</em>
+              <a data-start="14:30" data-end="15:15" data-content="networking_bingo" data-event="event-6" href="#0">
+                <em class="cd-schedule__name">Networking!</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="20:00" data-end="21:30" data-content="ses_under" data-event="event-2" href="#0">
-                <em class="cd-schedule__name">Data Acquisition</em>
+                <em class="cd-schedule__name">Transparent innovation: Pioneering vendor-agnostic data acquisition</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
-              <a data-start="21:30" data-end="22:00" data-content="tutorial_1" data-event="event-8" href="#0">
-                <em class="cd-schedule__name">Tutorial: Transparent Workflows</em>
+              <a data-start="21:30" data-end="22:15" data-content="tutorial_1" data-event="event-8" href="#0">
+                <em class="cd-schedule__name">Tutorial: Workflows</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="25:00" data-end="26:30" data-content="ses_under" data-event="event-2" href="#0">
-                <em class="cd-schedule__name">Data Acquisition</em>
+                <em class="cd-schedule__name">Cultivating openness: reproducible data acquisition</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
-              <a data-start="26:30" data-end="27:00" data-content="networking_1" data-event="event-6" href="#0">
-                <em class="cd-schedule__name">Networking Session</em>
+              <a data-start="26:30" data-end="27:15" data-content="networking_1" data-event="event-6" href="#0">
+                <em class="cd-schedule__name">Networking!</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="32:00" data-end="34:00" data-content="ses_under" data-event="event-4" href="#0">
-                <em class="cd-schedule__name">Data Sharing</em>
+                <em class="cd-schedule__name">MRI data liberation: Sharing for a better future</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="37:00" data-end="39:00" data-content="ses_under" data-event="event-3" href="#0">
-                <em class="cd-schedule__name">Open Source Software</em>
+                <em class="cd-schedule__name">Coding the future: the power of open source software</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="44:00" data-end="46:00" data-content="ses_under" data-event="event-5" href="#0">
-                <em class="cd-schedule__name">Beyond Academia</em>
+                <em class="cd-schedule__name">Perspectives in practice: beyond academia</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="49:00" data-end="51:00" data-content="ses_under" data-event="event-3" href="#0">
-                <em class="cd-schedule__name">Data Analysis</em>
+                <em class="cd-schedule__name">Tools for all: open source data analysis</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="56:00" data-end="58:00" data-content="ses_under" data-event="event-1" href="#0">
-                <em class="cd-schedule__name">Reproducible Science and Communities</em>
+                <em class="cd-schedule__name">Connecting minds: Communities for open and reproducible science</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="61:00" data-end="63:00" data-content="ses_under" data-event="event-2" href="#0">
-                <em class="cd-schedule__name">Pre-Clinical</em>
+                <em class="cd-schedule__name">From lab to life: in vitro and pre-clinical MRI with transparency</em>
               </a>
             </li>
 
             <li class="cd-schedule__event">
               <a data-start="68:00" data-end="70:00" data-content="ses_under" data-event="event-1" href="#0">
-                <em class="cd-schedule__name">Closing Session</em>
+                <em class="cd-schedule__name">Shaping the future of MRI: closing thoughts</em>
               </a>
             </li>
 
@@ -240,6 +240,14 @@ external_css: [assets/css/style.css]
             
           </ul>
         </div>  
+
+        <div class="cd-schedule__group">
+          <div class="cd-schedule__top-info"><span>Saturday <small>(8/13)</small></span></div>
+  
+          <ul id="Day4">
+            
+          </ul>
+        </div> 
       </ul>
     </div>
   

--- a/23m/schedule/networking_bingo.html
+++ b/23m/schedule/networking_bingo.html
@@ -1,0 +1,5 @@
+<div class="cd-schedule-modal__event-info">
+	<div class="blurb">
+        Join us on Gathertown for our first networking opportunity of MRI Together 2023. Come and meet your fellow attendees in a friendly get-to-know-you bingo competition for a chance to win prizes!
+    </div>
+</div>


### PR DESCRIPTION
Added a fourth day to the program to fix the closing session rolling over into Day 1 for some time zones.

Now that daylight savings has occurred worldwide, everyone seems to have the correct program times reported! No changes needed.

Added the updated program titles but removed the time stamps on the program boxes so that everything fits. Likewise, made the tutorials/networking sessions slightly longer to accommodate the titles. We can have some flexible overflow/hang-out time this way.

Still to do: add more speaker info/talk titles.